### PR TITLE
Set cookie at host root path

### DIFF
--- a/hub/github.go
+++ b/hub/github.go
@@ -101,7 +101,7 @@ func (g *githubSSO) ExchangeCodeForToken(w http.ResponseWriter, r *http.Request)
 	uname := *u.Login
 	avatar := *u.AvatarURL
 	g.storeGithubToken(cookieVal, accessToken, uname, avatar)
-	http.SetCookie(w, &http.Cookie{Name: "ghAuthToken", Value: cookieVal, Expires: time.Now().Add(90 * 24 * time.Hour)})
+	http.SetCookie(w, &http.Cookie{Name: "ghAuthToken", Path: "/", Value: cookieVal, Expires: time.Now().Add(90 * 24 * time.Hour)})
 	http.Redirect(w, r, "/", 302)
 }
 


### PR DESCRIPTION
Cookie was being set  at the authorisation subpath so requests to `"/"` didn't have access to the cookie, hence the logged in callback function was never called:

![screen shot 2015-04-12 at 01 54 44](https://cloud.githubusercontent.com/assets/1316984/7103944/f6b8d458-e0b6-11e4-8153-e3e9b233e81b.png)

Authorisation callback may vary in number of subpaths: `/auth/gh` would set cookie at `/auth`,etc

Only direct subpaths (like `/anything`) are working at the moment.
## 

Great stuff btw, I was about to write the exact same package for something I'm building so you might see a lot me in the near future hahah
